### PR TITLE
fix: JSON响应数据在Pre-response Script中格式错误

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,8 +298,9 @@
                             // 对于 JSON 响应，优先使用已解析的 data，确保返回对象格式
                             yapiRes = response.data;
                             
-                            // 如果 data 不存在或为空，尝试解析 body
-                            if (!yapiRes && response.body) {
+                            // 只有当 data 明确为 undefined 或 null 时才尝试重新解析 body
+                            // 避免将有效的 falsy 值（如 0, false, "", {}, []）误判为需要重新解析
+                            if ((yapiRes === undefined || yapiRes === null) && response.body) {
                                 try {
                                     yapiRes = JSON.parse(response.body);
                                     console.log('[Index] 从 body 重新解析 JSON 成功');


### PR DESCRIPTION
修复了在Pre-response Script中context.responseData不是JSON格式的问题。

**问题根因:**
- 原代码在index.js:302使用条件 `!yapiRes && response.body` 来判断是否需要重新解析JSON
- 但是 `!yapiRes` 对于有效的falsy值（如 {}, [], 0, false, ""）会错误地返回true
- 导致已经正确解析的JSON对象被重新解析，可能变成字符串格式

**修复方案:**
- 将条件改为 `(yapiRes === undefined || yapiRes === null) && response.body`
- 只有当response.data明确为undefined或null时才尝试重新解析
- 确保有效的JSON值（包括空对象、数组、数字、布尔值、字符串）正确传递给YApi

**影响范围:**
- YApi Pre-response Script中的context.responseData现在将正确接收JSON格式的数据
- 兼容所有有效的JSON值类型，包括falsy值

🤖 Generated with [Claude Code](https://claude.ai/code)